### PR TITLE
Travis Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ rvm:
   - 2.2.0
   - 2.1
   - 2.0
-  - 1.9.3
 script: "ruby lib/watson-api-client.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2.0
+  - 2.1
+  - 2.0
+  - 1.9.3
+script: "ruby lib/watson-api-client.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-ruby "1.9.3" rescue nil
-
 gem 'rest-client'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 1.9.3'
+
+ruby "1.9.3" rescue nil
 
 gem 'rest-client'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ================================================================
 
 [![Gem Version](https://badge.fury.io/rb/watson-api-client.svg)](http://badge.fury.io/rb/watson-api-client)
+[![Build Status](https://travis-ci.org/blueboxjesse/watson-api-client.svg?branch=master)](https://travis-ci.org/blueboxjesse/watson-api-client)
 
 The [watson-api-client](http://rubygems.org/gems/watson-api-client) is a gem to use REST API on the IBM Watson™ Developer Cloud.
 


### PR DESCRIPTION
Adds support for Travis CI testing to at the very least ensure the app will start. Once we have further details from the comments in #2, will amend the tests.

Additionally, rest-client 2.0 is no longer supporting Ruby 1.9.3, so we need to strip that from our  Gemfile.
